### PR TITLE
feat: add ISR with hourly revalidation for homepage

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -3,6 +3,19 @@ import MetadataBuilder from "@/components/MetadataBuilder";
 import type { Metadata } from "next";
 import { setRequestLocale } from "next-intl/server";
 
+// Revalidate every hour (3600 seconds)
+export const revalidate = 3600;
+
+export function generateStaticParams() {
+  return [
+    { locale: "en" },
+    { locale: "es" },
+    { locale: "he" },
+    { locale: "ru" },
+    { locale: "de" },
+  ];
+}
+
 export async function generateMetadata({
   params,
 }: {

--- a/src/app/dynamicRendering/index.tsx
+++ b/src/app/dynamicRendering/index.tsx
@@ -39,6 +39,7 @@ export const fetchOnePage = async (slug: string, locale: string) => {
 				Authorization: `bearer ${process.env.STRAPI_API_TOKEN}`,
 				"Strapi-Response-Format": "v4",
 			},
+			next: { revalidate: 3600 },
 		});
 		const data = await res.json();
 		// console.log(data["data"][0]["attributes"])


### PR DESCRIPTION
- Configured Incremental Static Regeneration with 1-hour cache for homepage and CMS content
- Added static params generation for all supported locales (en, es, he, ru, de)